### PR TITLE
[feat] Add function to process one file

### DIFF
--- a/fetchAZA/convertAZA.py
+++ b/fetchAZA/convertAZA.py
@@ -1,0 +1,106 @@
+import pandas as pd
+import xarray as xr
+import re
+from collections import defaultdict
+from fetchAZA import tools, readers, writers
+import numpy as np
+
+import glob
+import re
+import os
+import datetime
+import yaml
+import pathlib
+import logging
+_log = logging.getLogger(__name__)
+
+def convertAZA(data_path, fn, STN='sample', deploy_date='2000-01-01', recovery_date='2099-01-01', latitude='0', longitude='0', water_depth='0', cleanup=True):
+    """
+    Processes and converts AZA data from CSV to netCDF format.
+
+    Parameters
+    ----------
+    data_path : str
+        Path to the data directory.
+    fn : str
+        Filename of the input CSV file.
+    STN : str
+        Station identifier.
+    deploy_date : str
+        Deployment date in 'YYYY-MM-DD' format.
+    recovery_date : str
+        Recovery date in 'YYYY-MM-DD' format.
+    latitude : float
+        Latitude of the station.
+    longitude : float
+        Longitude of the station.
+    water_depth : float
+        Water depth at the station.
+
+    Returns
+    -------
+    tuple
+        ds_pressure and ds_AZA datasets.
+    """
+    # Process filename
+    file_path = os.path.join(data_path, fn)
+    file_root = fn.split('.')[0]
+    platform_id = file_root
+    today = datetime.datetime.now()
+    start_time = today.strftime("%Y%m%dT%H")
+
+    # Create a log file
+    log_file = os.path.join(data_path, f"{platform_id}_{start_time}_read.log")
+    logf_with_path = os.path.join(data_path, log_file)
+    # Create the log file
+    logging.basicConfig(
+        filename=logf_with_path, 
+        encoding='utf-8',
+        format="%(asctime)s %(levelname)-8s %(funcName)s %(message)s",
+        filemode="w", # 'w' to overwrite, 'a' to append
+        level=logging.INFO,
+        datefmt="%Y%m%dT%H%M%S",
+        force=True,
+    )
+    _log.info('Reading AZA from CSV to netCDF')
+    _log.info('Processing data from: %s', file_path)
+
+    # Convert the data
+    datasets = readers.read_csv_to_xarray(file_path)
+    # Save intermediate files
+    writers.save_datasets(datasets, file_path)
+    # Process the data
+    ds_pressure, ds_AZA = tools.process_datasets(data_path, file_root, deploy_date, recovery_date)
+    # Save the datasets
+    # Add attributes to ds_pressure
+    ds_pressure.attrs.update({
+        'Station': STN,
+        'Latitude': latitude,
+        'Longitude': longitude,
+        'Water_Depth': water_depth,
+        'Start_Time': deploy_date,
+        'End_Time': recovery_date
+    })
+
+    # Add attributes to ds_AZA
+    ds_AZA.attrs.update({
+        'Station': STN,
+        'Latitude': latitude,
+        'Longitude': longitude,
+        'Water_Depth': water_depth,
+        'Start_Time': deploy_date,
+        'End_Time': recovery_date
+    })
+
+    output_file = os.path.join(data_path, f"{STN}_{deploy_date.replace('-','').replace('/','')}_use.nc")
+    writers.save_dataset(ds_pressure, output_file)
+
+    output_file = os.path.join(data_path, f"{STN}_{deploy_date.replace('-','').replace('/','')}_AZA.nc")
+    writers.save_dataset(ds_AZA, output_file)
+
+    if cleanup:
+        # Delete the intermediate files
+        _log.info('Deleting intermediate files')
+        writers.delete_netcdf_datasets(data_path, file_root, keys=['KLR','DQZ','PIES','TMP','INC'])
+
+    return ds_pressure, ds_AZA

--- a/fetchAZA/convertAZA.py
+++ b/fetchAZA/convertAZA.py
@@ -101,6 +101,6 @@ def convertAZA(data_path, fn, STN='sample', deploy_date='2000-01-01', recovery_d
     if cleanup:
         # Delete the intermediate files
         _log.info('Deleting intermediate files')
-        writers.delete_netcdf_datasets(data_path, file_root, keys=['KLR','DQZ','PIES','TMP','INC'])
+        writers.delete_netcdf_datasets(data_path, file_root, keys)
 
     return ds_pressure, ds_AZA

--- a/fetchAZA/writers.py
+++ b/fetchAZA/writers.py
@@ -4,7 +4,56 @@ from numbers import Number
 import os
 from fetchAZA import utilities
 import logging
+import glob
+import re
+import datetime
 _log = logging.getLogger(__name__)
+
+
+def delete_netcdf_datasets(data_path, file_root, keys=None):
+    """
+    Delete netCDF files matching the given file_root and optional keys from the specified data_path.
+
+    Parameters
+    ----------
+    data_path : str 
+        The directory path where the netCDF files are located.
+    file_root : str 
+        The root name of the files to match.
+    keys : list of str, optional
+        A list of keys to filter the files. Only files containing these keys in their names will be deleted.
+        If None, all matching files will be deleted.
+
+    Returns
+    -------
+    int 
+        The number of files successfully deleted.
+    """
+    # Find matching netCDF files
+    search_dir = os.path.join(data_path, f"{file_root}*.nc")
+    matching_files = glob.glob(search_dir)
+
+    # Filter files based on keys if provided
+    if keys is not None:
+        matching_files = [
+            file for file in matching_files
+            if any(f"{file_root}_{key}" in os.path.basename(file) for key in keys)
+        ]
+
+    # Delete the matching netCDF files
+    deleted_count = 0
+    for file in matching_files:
+        try:
+            print(f"Deleting file: {file}")
+            os.remove(file)
+            _log.info(f"Deleted file: {file}")
+            deleted_count += 1
+        except Exception as e:
+            _log.error(f"Failed to delete file: {file}. Error: {e}")
+
+    _log.info(f"Deleted {deleted_count} files matching '{file_root}' with keys {keys}.")
+
+    return deleted_count
 
 def save_dataset(ds, output_file='../data/test.nc'):
     """

--- a/fetchAZA/writers.py
+++ b/fetchAZA/writers.py
@@ -10,7 +10,7 @@ import datetime
 _log = logging.getLogger(__name__)
 
 
-def delete_netcdf_datasets(data_path, file_root, keys=None):
+def delete_netcdf_datasets(data_path, file_root, keys=['KLR','DQZ','PIES','TMP','INC']):
     """
     Delete netCDF files matching the given file_root and optional keys from the specified data_path.
 

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "6a1920f3",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
     "import matplotlib.pyplot as plt\n",
     "import importlib\n",
     "import datetime\n",
-    "from fetchAZA import readers, writers, plotters, tools, timetools, utilities\n",
+    "from fetchAZA import convertAZA, readers, writers, plotters, tools, timetools, utilities\n",
     "import warnings\n",
     "import re\n",
     "import glob\n",
@@ -53,7 +53,61 @@
     "fig_path = os.path.join(parent_dir, 'figures')\n",
     "\n",
     "warnings.filterwarnings(\"ignore\", message=\"In a future version of xarray decode_timedelta will default to False rather than None. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.\")\n",
-    "warnings.filterwarnings(\"ignore\", category=xr.SerializationWarning, message=\"SerializationWarning: Can't decode floating point timedelta to 's' without precision loss, decoding to 'ns' instead. To silence this warning use time_unit='ns' in call to decoding function.\")"
+    "warnings.filterwarnings(\"ignore\", category=xr.SerializationWarning, message=\"SerializationWarning: Can't decode floating point timedelta to 's' without precision loss, decoding to 'ns' instead. To silence this warning use time_unit='ns' in call to decoding function.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1508e1e7",
+   "metadata": {},
+   "source": [
+    "## Step 1 & 2 as convertAZA.convertAZA\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "721efe8c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data*.nc\n",
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_KLR.nc\n",
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_AZAseq.nc\n",
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_INC.nc\n",
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_TMP.nc\n",
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_DQZ.nc\n",
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_PIES.nc\n",
+      "Dataset AZAseq not included in combined datasets\n",
+      "Deleting file: /Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_KLR.nc\n",
+      "Deleting file: /Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_TMP.nc\n",
+      "Deleting file: /Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_DQZ.nc\n",
+      "Deleting file: /Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/data/sample_data_PIES.nc\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/fetchAZA/fetchAZA/writers.py:96: UserWarning: Times can't be serialized faithfully to int64 with requested units 'seconds since 1970-01-01'. Resolution of 'milliseconds' needed. Serializing times to floating point instead. Set encoding['dtype'] to integer dtype to serialize to int64. Set encoding['dtype'] to floating point dtype to silence this warning.\n",
+      "  ds.to_netcdf(output_file)\n"
+     ]
+    }
+   ],
+   "source": [
+    "fn = 'sample_data.csv'\n",
+    "STN = 'sample'\n",
+    "deploy_date = '2023-02-27'\n",
+    "recovery_date = '2023-03-08T08:00:00'\n",
+    "latitude = 26.5\n",
+    "longitude = -76.75\n",
+    "water_depth = -3800\n",
+    "\n",
+    "ds_pressure, ds_AZA = convertAZA.convertAZA(data_path, fn, STN, deploy_date, recovery_date, latitude, longitude, water_depth, True)"
    ]
   },
   {
@@ -77,7 +131,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "importlib.reload(readers)\n",
     "fn = 'sample_data.csv'\n",
     "STN = 'sample'\n",
     "deploy_date = '2023-02-27'\n",


### PR DESCRIPTION
Now run through the whole processing setup.

In `fetchAZA.convertAZA.py`, added function `convertAZA()` which takes as inputs the data_path, filename, attributes, and a boolean `cleanup` to delete extra interim netCDF files.  It writes the data to netCDF and returns the data in xarray, and also writes a log file explaining what has been done.

Runs:
- `readers.read_csv_to_xarray(file_path)`
- `writers.save_datasets(datasets, file_path)` which saves the intermediate datasets as netCDF (one per Logging Event type)
- `tools.process_datasets(data_path, file_root, deploy_date, recovery_date)` which combines the pressure, temperature and inclinometer data (hourly) into `ds_pressure`, and combines the AZA and AZS data which match the expected sequence of "AZS-AZA-AZA-AZA-AZS", and also cuts the data to the deployment period (between deploy_date and recovery_date).
- Attributes are added based on the inputs to `convertAZA()`
- `writers.save_dataset(ds_pressure, output_file)` and `writers.save_dataset(ds_AZA, output_file)` save these to the data_path
- Optional (if `cleanup=True`): the netCDF files containing Logging Events which are contained within the combined netCDF files `*_use.nc` and `*_AZA.nc` are deleted.